### PR TITLE
Save Last location feature, and config menu.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -21,6 +21,18 @@ repositories {
         name = "Gegy"
         url = uri("https://maven.gegy.dev")
     }
+    maven {
+        name = "shedaniel"
+        url = uri("https://maven.shedaniel.me/")
+    }
+
+    maven {
+        name = "Modrinth"
+        url = uri("https://api.modrinth.com/maven")
+        content {
+            includeGroup("maven.modrinth");
+        }
+    }
 }
 
 dependencies {
@@ -33,6 +45,11 @@ dependencies {
 
     modImplementation("net.fabricmc.fabric-api:fabric-api:${properties["fabric_version"].toString()}")
 
+    modImplementation("me.shedaniel.cloth:cloth-config-fabric:${properties["cloth_config_version"]}") {
+        exclude("net.fabricmc.fabric-api")
+    }
+
+    modCompileOnly("maven.modrinth:modmenu:${properties["modmenu_version"]}");
 
     include(implementation("com.electronwill.night-config:core:${properties["night_config_version"].toString()}")!!)
     include(implementation("com.electronwill.night-config:toml:${properties["night_config_version"].toString()}")!!)

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ org.gradle.jvmargs=-Xmx1G
 	quilt_mappings=1
 
 # Mod Properties
-	mod_version = 0.1.0
+	mod_version = 0.1.1
 	maven_group = net.sorenon
 	archives_base_name = titleworlds
 
@@ -16,4 +16,4 @@ org.gradle.jvmargs=-Xmx1G
 	databreaker_version = 0.2.8
     night_config_version=3.6.5
 	cloth_config_version=7.0.72
-	modmenu_version=3.1.0
+	modmenu_version=4.0.4

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,5 @@ org.gradle.jvmargs=-Xmx1G
 	fabric_version=0.57.0+1.19
 	databreaker_version = 0.2.8
     night_config_version=3.6.5
+	cloth_config_version=7.0.72
+	modmenu_version=3.1.0

--- a/src/main/java/net/sorenon/titleworlds/TWConfigGUI.java
+++ b/src/main/java/net/sorenon/titleworlds/TWConfigGUI.java
@@ -1,0 +1,40 @@
+package net.sorenon.titleworlds;
+
+import me.shedaniel.clothconfig2.api.ConfigBuilder;
+import me.shedaniel.clothconfig2.api.ConfigCategory;
+import me.shedaniel.clothconfig2.gui.entries.BooleanListEntry;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.network.chat.Component;
+
+@Environment(EnvType.CLIENT)
+public class TWConfigGUI {
+
+    // Config system borrowed from https://github.com/qouteall/ImmersivePortalsMod and adapted here thank you
+
+    public static Screen createConfigScreen(Screen parent) {
+
+        TWConfigUtil config = TWConfigUtil.getConfig();
+
+        ConfigBuilder configBuilder = ConfigBuilder.create();
+        ConfigCategory clientcategory = configBuilder.getOrCreateCategory(Component.translatable("Client Config"));
+
+        BooleanListEntry screenshotOnExit = configBuilder.entryBuilder().startBooleanToggle(
+                Component.translatable("3D screenshot on world exit"),
+                config.ScreenshotOnExit
+        ).setDefaultValue(false).build();
+
+        clientcategory.addEntry(screenshotOnExit);
+        return configBuilder.setParentScreen(parent)
+                .setSavingRunnable(() -> {
+                    TWConfigUtil newConfig = new TWConfigUtil();
+                    newConfig.ScreenshotOnExit = screenshotOnExit.getValue();
+                    newConfig.saveConfigFile();
+                    newConfig.onConfigChanged();
+                })
+                .build();
+
+    }
+
+}

--- a/src/main/java/net/sorenon/titleworlds/TWConfigGlobal.java
+++ b/src/main/java/net/sorenon/titleworlds/TWConfigGlobal.java
@@ -1,0 +1,10 @@
+package net.sorenon.titleworlds;
+
+// Config system borrowed from https://github.com/qouteall/ImmersivePortalsMod and adapted here thank you
+
+
+public class TWConfigGlobal {
+
+    public static boolean ScreenshotOnExit = false;
+
+}

--- a/src/main/java/net/sorenon/titleworlds/TWConfigModMenu.java
+++ b/src/main/java/net/sorenon/titleworlds/TWConfigModMenu.java
@@ -1,0 +1,14 @@
+package net.sorenon.titleworlds;
+import com.terraformersmc.modmenu.api.ConfigScreenFactory;
+import com.terraformersmc.modmenu.api.ModMenuApi;
+
+public class TWConfigModMenu  implements ModMenuApi {
+
+    public TWConfigModMenu() {}
+
+    @Override
+    public ConfigScreenFactory<?> getModConfigScreenFactory() {
+        return TWConfigGUI::createConfigScreen;
+    }
+
+}

--- a/src/main/java/net/sorenon/titleworlds/TWConfigUtil.java
+++ b/src/main/java/net/sorenon/titleworlds/TWConfigUtil.java
@@ -1,0 +1,86 @@
+package net.sorenon.titleworlds;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import net.fabricmc.loader.api.FabricLoader;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.stream.Collectors;
+
+public class TWConfigUtil {
+
+    // Config system borrowed from https://github.com/qouteall/ImmersivePortalsMod and adapted here thank you
+
+    public boolean ScreenshotOnExit = false;
+
+    public static Gson gson = new GsonBuilder().setPrettyPrinting().create();
+
+    private static File getGameDir() {
+        Path gameDir = FabricLoader.getInstance().getGameDir();
+        return gameDir.toFile();
+    }
+
+    public static TWConfigUtil getConfig() {
+
+        File ConfigFile = getConfigFileLocation();
+
+        return readConfigFromFile(ConfigFile);
+
+    }
+
+    public static File getConfigFileLocation() {
+        return new File(
+                getGameDir(), "config/titleworlds.json"
+        );
+    }
+
+    public static TWConfigUtil readConfigFromFile(File configFile) {
+        if (configFile.exists()) {
+            try {
+                String data = Files.lines(configFile.toPath()).collect(Collectors.joining());
+                TWConfigUtil result = gson.fromJson(data, TWConfigUtil.class);
+
+                if (result == null) {
+                    return new TWConfigUtil();
+                }
+
+                return result;
+            }
+            catch (Throwable e) {
+                e.printStackTrace();
+                return new TWConfigUtil();
+            }
+        }
+        else {
+            TWConfigUtil configObj = new TWConfigUtil();
+            configObj.saveConfigFile();
+            return configObj;
+        }
+
+    }
+
+    public void saveConfigFile() {
+        File configFile  = getConfigFileLocation();
+
+        try {
+            configFile.getParentFile().mkdir();
+            configFile.createNewFile();
+            FileWriter fw = new FileWriter(configFile);
+
+            fw.write(gson.toJson(this));
+            fw.close();
+        }
+        catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public void onConfigChanged() {
+        TWConfigGlobal.ScreenshotOnExit = ScreenshotOnExit;
+    }
+
+}

--- a/src/main/java/net/sorenon/titleworlds/TitleWorldsMod.java
+++ b/src/main/java/net/sorenon/titleworlds/TitleWorldsMod.java
@@ -28,13 +28,22 @@ public class TitleWorldsMod implements ClientModInitializer {
     public static State state = new State();
 
     public static LevelStorageSource levelSource;
+    public static LevelStorageSource saveOnExitSource;
 
     @Override
     public void onInitializeClient() {
+
+        TWConfigUtil configutil = TWConfigUtil.getConfig();
+        configutil.onConfigChanged();
+        configutil.saveConfigFile();
+
         LOGGER.info("Opening level storage source");
         Minecraft minecraft = Minecraft.getInstance();
         Path titleWorldsPath = minecraft.gameDirectory.toPath().resolve("titleworlds");
+        Path exitOnSavePath = titleWorldsPath.resolve("latest");
+
         levelSource = new LevelStorageSource(titleWorldsPath, minecraft.gameDirectory.toPath().resolve("titleworldbackups"), minecraft.getFixerUpper());
+        saveOnExitSource = new LevelStorageSource(exitOnSavePath, minecraft.gameDirectory.toPath().resolve("titleworldbackups"), minecraft.getFixerUpper());
 
         keyBinding = KeyBindingHelper.registerKeyBinding(new KeyMapping(
                 "key.titleworlds.opentitlescreen",

--- a/src/main/java/net/sorenon/titleworlds/mixin/MinecraftMixin.java
+++ b/src/main/java/net/sorenon/titleworlds/mixin/MinecraftMixin.java
@@ -36,6 +36,7 @@ import net.minecraft.util.thread.ReentrantBlockableEventLoop;
 import net.minecraft.world.level.DataPackConfig;
 import net.minecraft.world.level.block.entity.SkullBlockEntity;
 import net.minecraft.world.level.storage.*;
+import net.sorenon.titleworlds.TWConfigGlobal;
 import net.sorenon.titleworlds.TitleWorldsMod;
 import net.sorenon.titleworlds.mixin.accessor.WorldOpenFlowsAcc;
 import org.apache.logging.log4j.LogManager;
@@ -206,12 +207,19 @@ public abstract class MinecraftMixin extends ReentrantBlockableEventLoop<Runnabl
     public boolean tryLoadTitleWorld() {
         try {
             var list = TitleWorldsMod.levelSource.findLevelCandidates().levels();
+
+            if (TWConfigGlobal.ScreenshotOnExit) {
+                list = TitleWorldsMod.saveOnExitSource.findLevelCandidates().levels();
+            }
+
             if (list.isEmpty()) {
                 LOGGER.info("TitleWorlds folder is empty");
                 return false;
             }
+
             this.loadTitleWorld(list.get(random.nextInt(list.size())).directoryName());
             return true;
+
         } catch (ExecutionException | InterruptedException | LevelStorageException e) {
             LOGGER.error("Exception when loading title world", e);
             return false;
@@ -332,6 +340,10 @@ public abstract class MinecraftMixin extends ReentrantBlockableEventLoop<Runnabl
         LevelStorageSource.LevelStorageAccess levelStorageAccess;
         try {
             levelStorageAccess = TitleWorldsMod.levelSource.createAccess(levelName);
+
+            if (TWConfigGlobal.ScreenshotOnExit)
+                levelStorageAccess = TitleWorldsMod.saveOnExitSource.createAccess(levelName);
+
         } catch (IOException var21) {
             throw new RuntimeException("Failed to read data");
         }

--- a/src/main/java/net/sorenon/titleworlds/mixin/PauseMenuMixin.java
+++ b/src/main/java/net/sorenon/titleworlds/mixin/PauseMenuMixin.java
@@ -1,0 +1,57 @@
+package net.sorenon.titleworlds.mixin;
+
+import com.mojang.realmsclient.RealmsMainScreen;
+import net.minecraft.client.Screenshot;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.screens.GenericDirtMessageScreen;
+import net.minecraft.client.gui.screens.PauseScreen;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.gui.screens.TitleScreen;
+import net.minecraft.client.gui.screens.multiplayer.JoinMultiplayerScreen;
+import net.minecraft.network.chat.Component;
+import net.sorenon.titleworlds.Screenshot3D;
+import net.sorenon.titleworlds.TWConfigGlobal;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(PauseScreen.class)
+public abstract class PauseMenuMixin extends Screen {
+
+    protected PauseMenuMixin(Component component) {
+        super(component);
+    }
+
+    @Inject(method = "createPauseMenu", at = @At(value = "INVOKE", ordinal = 7, target = "Lnet/minecraft/client/gui/screens/PauseScreen;addRenderableWidget(Lnet/minecraft/client/gui/components/events/GuiEventListener;)Lnet/minecraft/client/gui/components/events/GuiEventListener;"), cancellable = true)
+    public void createPauseMenuMixin(CallbackInfo ci) {
+        ci.cancel();
+        Component component = this.minecraft.isLocalServer() ? Component.translatable("menu.returnToMenu") : Component.translatable("menu.disconnect");
+        this.addRenderableWidget(new Button(this.width / 2 - 102, this.height / 4 + 120 + -16, 204, 20, component, (buttonx) -> {
+            boolean bl = this.minecraft.isLocalServer();
+            boolean bl2 = this.minecraft.isConnectedToRealms();
+            buttonx.active = false;
+            this.minecraft.level.disconnect();
+            if (bl) {
+
+                if (TWConfigGlobal.ScreenshotOnExit)
+                    Screenshot3D.take3DScreenshotOnExit(this.minecraft.level);
+
+                this.minecraft.clearLevel(new GenericDirtMessageScreen(Component.translatable("menu.savingLevel")));
+            } else {
+                this.minecraft.clearLevel();
+            }
+
+            TitleScreen titleScreen = new TitleScreen();
+            if (bl) {
+                this.minecraft.setScreen(titleScreen);
+            } else if (bl2) {
+                this.minecraft.setScreen(new RealmsMainScreen(titleScreen));
+            } else {
+                this.minecraft.setScreen(new JoinMultiplayerScreen(titleScreen));
+            }
+
+        }));
+    }
+
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -19,6 +19,9 @@
   "entrypoints": {
     "client": [
       "net.sorenon.titleworlds.TitleWorldsMod"
+    ],
+    "modmenu" :[
+      "net.sorenon.titleworlds.TWConfigModMenu"
     ]
   },
   "mixins": [

--- a/src/main/resources/titleworlds.mixins.json
+++ b/src/main/resources/titleworlds.mixins.json
@@ -24,7 +24,8 @@
     "cancel_save.needed.ChunkMapMixin",
     "cancel_save.needed.EntityStorageMixin",
     "cancel_save.needed.MinecraftServerMixin",
-    "cancel_save.needed.PlayerListMixin"
+    "cancel_save.needed.PlayerListMixin",
+    "PauseMenuMixin"
   ],
   "injectors": {
     "defaultRequire": 1


### PR DESCRIPTION
Added config menu and new feature where when enabled, title worlds will save the last single player world you were on and use that as the title world.


https://user-images.githubusercontent.com/44146685/179896292-05c8960c-5ed1-405a-b679-07ac46c5c6d8.mp4

One bug remains in here though, i have no idea how to fix it. Essentially when a title world is saved on exit it should only save in the "titleworlds/latest" folder. But for some reason, every time its also creating another folder in the root titleworlds folder with only a "session.lock" inside of it.

Example after 4 times exiting the game.

![image](https://user-images.githubusercontent.com/44146685/179896732-9a0c88ca-1fb5-4ae6-ab82-c40219e22901.png)
